### PR TITLE
Change to confirmCardPayment from handleCardPayment

### DIFF
--- a/client/src/components/CheckoutForm.js
+++ b/client/src/components/CheckoutForm.js
@@ -48,7 +48,7 @@ class CheckoutForm extends Component {
 
         // Step 2: Use clientSecret from PaymentIntent to handle payment in stripe.handleCardPayment() call
         this.props.stripe
-          .handleCardPayment(this.state.clientSecret)
+          .confirmCardPayment(this.state.clientSecret)
           .then(payload => {
             if (payload.error) {
               this.setState({


### PR DESCRIPTION
Example is using a method that has been deprecated, updated it to match current guidance in docs: https://stripe.com/docs/stripe-js/reference#stripe-confirm-card-payment

FYI this is @stevehind from Stripe ... this is my personal account.