### PR TITLE
Fix python server error

### DIFF
--- a/server/python/server.py
+++ b/server/python/server.py
@@ -44,7 +44,7 @@ def get_product_details():
 @app.route('/create-payment-intent', methods=['POST'])
 def post_payment_intent():
     # Reads application/json and returns a response
-    data = json.loads(request.data)
+    data = json.loads(request.data or '{}')
     product = product_details()
 
     options = dict()
@@ -52,7 +52,7 @@ def post_payment_intent():
     options.update(product)
     
     # Create a PaymentIntent with the order amount and currency
-    payment_intent = stripe.PaymentIntent.create(options)
+    payment_intent = stripe.PaymentIntent.create(**options)
 
     try:
         return jsonify(payment_intent)


### PR DESCRIPTION
This pull request contains two changes on Python server code where it
(1) parses JSON passed from client
(2) passes params to Stripe API

(1)
The current client implementation sends blank data to the server and the python server fails to parse it.
I make it work by providing a blank object string `{}` for default.
I choose to change only the python code because other languages may depends on the current client implementation.

(2) 
Fixed passing a Python dictionary as keyword params to a function.

