### PR TITLE
chore: fix node version for running local API

### DIFF
--- a/server/node/package.json
+++ b/server/node/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "engines": {
-    "node": "^10.13.0"
+    "node": ">=10.13.0"
   },
   "author": "stripe-demos",
   "license": "ISC",


### PR DESCRIPTION
## Summary
When I tried to run the node API in local, I failed because of node version's incompatibility as follows.

```
$ node --version
v12.13.0

$ yarn start
yarn run v1.22.10
$ concurrently "yarn client" "yarn server"
$ cd client && yarn start
$ cd server/node && yarn start
$ react-scripts start
[0] /bin/sh: react-scripts: command not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error stripe-recipe-demo@1.0.0: The engine "node" is incompatible with this module. Expected version "^10.13.0". Got "12.13.0"
error Commands cannot run with an incompatible environment.
```

So I updated package.json for fixing this problem.